### PR TITLE
ObjectIdentifier failable initializer

### DIFF
--- a/Sources/ASN1Kit/ObjectIdentifier.swift
+++ b/Sources/ASN1Kit/ObjectIdentifier.swift
@@ -143,6 +143,12 @@ extension ObjectIdentifier: ASN1CodableType {
     }
 }
 
+extension ObjectIdentifier: CustomStringConvertible {
+    public var description: String {
+        return self.rawValue
+    }
+}
+
 extension String {
     static let oidRegex = try! NSRegularExpression(pattern: "^(((0|1)\\.([1-3][0-9]|[0-9])(\\.([1-9]([0-9])*|0))?)|(2\\.([1-9]([0-9]*)|[0-9])))(\\.([1-9]([0-9])*|0))*$")
     //swiftlint:disable:previous force_try line_length

--- a/Tests/ASN1KitTests/ObjectIdentifierTest.swift
+++ b/Tests/ASN1KitTests/ObjectIdentifierTest.swift
@@ -29,6 +29,7 @@ class ObjectIdentifierTest: XCTestCase {
     func testParsingInvalidOIDsParameterized() {
         for oid in invalidOIDs {
             expect(try ObjectIdentifier.from(string: oid)).to(throwError())
+            expect(try ObjectIdentifier(rawValue: oid)).to(beNil())
         }
     }
 
@@ -89,6 +90,7 @@ class ObjectIdentifierTest: XCTestCase {
 
     func encodingTest(oid: String, expected asn1: Data) {
         expect(try ObjectIdentifier.from(string: oid).asn1encode(tag: nil).serialize()) == asn1
+        expect(try ObjectIdentifier(rawValue: oid)?.asn1encode(tag: nil).serialize()) == asn1
     }
 
     func testDecodingParameterized() {

--- a/Tests/ASN1KitTests/ObjectIdentifierTest.swift
+++ b/Tests/ASN1KitTests/ObjectIdentifierTest.swift
@@ -144,6 +144,10 @@ class ObjectIdentifierTest: XCTestCase {
             let decodedOID = try ASN1Decoder.decode(asn1: asn1)
             return try ObjectIdentifier(from: decodedOID).rawValue
         } == oid
+        expect {
+            let decodedOID = try ASN1Decoder.decode(asn1: asn1)
+            return String(describing: try ObjectIdentifier(from: decodedOID))
+        } == oid
     }
 
     static var allTests = [


### PR DESCRIPTION
Add a failable non-throwing initializer to ObjectIdentifier, to increase ergonomics when initializing OIDs.