### PR TITLE
Store encoded ASN.1 for further use

### DIFF
--- a/Sources/ASN1Kit/ASN1Object.swift
+++ b/Sources/ASN1Kit/ASN1Object.swift
@@ -37,6 +37,9 @@ public protocol ASN1Object {
 
     /// Whether the object is a constructed object.
     var constructed: Bool { get }
+    
+    /// The original encoding
+    var originalEncoding: Data? { get }
 }
 
 extension ASN1Object {
@@ -60,6 +63,7 @@ public func create(tag: ASN1DecodedTag, data: ASN1Data) -> ASN1Object {
 internal struct ASN1Primitive {
     let data: ASN1Data
     let tag: ASN1DecodedTag
+    var originalEncoding: Data?
 }
 
 extension ASN1Primitive: ASN1Object {

--- a/Sources/ASN1Kit/DataScanner.swift
+++ b/Sources/ASN1Kit/DataScanner.swift
@@ -25,6 +25,7 @@ internal class DataScanner {
 
     /// The current position of the scanning head
     private var position = 0
+    private var marker: Int?
 
     required init(data: Data) {
         self.data = data
@@ -81,5 +82,20 @@ internal class DataScanner {
         }
 
         return data.subdata(in: position..<position + bytes)
+    }
+
+    func mark() {
+        self.marker = position
+    }
+
+    func unmark() {
+        self.marker = nil
+    }
+
+    var marked: Data? {
+        guard let marker = self.marker else {
+            return nil
+        }
+        return self.data.subdata(in: marker..<position)
     }
 }

--- a/Tests/ASN1KitTests/ASN1PrimitiveEncodingTest.swift
+++ b/Tests/ASN1KitTests/ASN1PrimitiveEncodingTest.swift
@@ -41,6 +41,7 @@ class ASN1PrimitiveEncodingTest: XCTestCase {
         expect(output.buffer) == expected
 
         expect(try ASN1Decoder.decode(asn1: output.buffer).asEquatable()) == implicitTag.asEquatable()
+        expect(try ASN1Decoder.decode(asn1: output.buffer).originalEncoding) == expected
     }
 
     static var allTests = [


### PR DESCRIPTION
It can be useful to store the encoding for future use, for example to verify a signature of encoded type without re-encoding (which can fail due to different encodings).

Note: there may be a more efficient way to do this that stores a view into the Data rather than copying.