### PR TITLE
Add support for encoding UInt

### DIFF
--- a/Sources/ASN1Kit/encodable/Int+ASN1Encoding.swift
+++ b/Sources/ASN1Kit/encodable/Int+ASN1Encoding.swift
@@ -43,3 +43,26 @@ extension Int: ASN1EncodableType {
         }.asn1encode(tag: .universal(.integer))
     }
 }
+
+extension UInt: ASN1EncodableType {
+    public func asn1encode(tag: ASN1DecodedTag?) throws -> ASN1Object {
+        let uintSize = MemoryLayout<UInt>.size
+        var littleEndian = self.littleEndian
+        return withUnsafePointer(to: &littleEndian) { unbound -> Data in
+            return unbound.withMemoryRebound(to: UInt8.self, capacity: uintSize) { bytes -> Data in
+                var shift = 0
+                // find out how many bytes we need (minimum) for DER-encoding
+                var value = UInt(self)
+                repeat {
+                    shift += 1
+                    value >>= 8
+                } while value > 0
+                var data = Data(bytes: bytes, count: shift)
+                if shift > 0, bytes[shift - 1] & 0x80 != 0 {
+                    data.append(contentsOf: [0x00])
+                }
+                return Data(data.reversed()) // Return BigEndian
+            }
+        }.asn1encode(tag: .universal(.integer))
+    }
+}

--- a/Sources/ASN1Kit/encodable/Int+ASN1Encoding.swift
+++ b/Sources/ASN1Kit/encodable/Int+ASN1Encoding.swift
@@ -40,7 +40,7 @@ extension Int: ASN1EncodableType {
                 let data = Data(bytes: bytes, count: shift)
                 return Data(data.reversed()) // Return BigEndian
             }
-        }.asn1encode(tag: .universal(.integer))
+        }.asn1encode(tag: tag ?? .universal(.integer))
     }
 }
 
@@ -63,6 +63,6 @@ extension UInt: ASN1EncodableType {
                 }
                 return Data(data.reversed()) // Return BigEndian
             }
-        }.asn1encode(tag: .universal(.integer))
+        }.asn1encode(tag: tag ?? .universal(.integer))
     }
 }

--- a/Tests/ASN1KitTests/encodable/IntExtASN1EncodingTest.swift
+++ b/Tests/ASN1KitTests/encodable/IntExtASN1EncodingTest.swift
@@ -73,6 +73,34 @@ final class IntExtASN1EncodingTest: XCTestCase {
         let expected = Data(bytes)
         expect { try Int.max.asn1encode(tag: nil).data.primitive } == expected
     }
+    
+    func testUInt_0x0080_toASN1() {
+        // tag::encodeSwiftPrimitives[]
+        //0x0080 = 128
+        let expected = Data([0x00, 0x80])
+        expect(try UInt(128).asn1encode(tag: nil).data.primitive) == expected
+        // end::encodeSwiftPrimitives[]
+    }
+
+    func testUInt_0x7FFFFF_toASN1() {
+        //0x7FFFFF = 8388607
+        let expected = Data([0x7F, 0xFF, 0xFF])
+        expect { try UInt(8388607).asn1encode(tag: nil).data.primitive } == expected
+    }
+
+    func testMinUInt_toASN1() {
+        // Test ASN1Integer UInt.min
+        let expected = Data([0x00])
+        expect { try UInt.min.asn1encode(tag: nil).data.primitive } == expected
+    }
+
+    func testMaxUInt_toASN1() {
+        // Test ASN1Integer UInt.max
+        let size = MemoryLayout<UInt>.size
+        let bytes = [UInt8](repeating: 0xff, count: size)
+        let expected = Data([0x00] + bytes)
+        expect { try UInt.max.asn1encode(tag: nil).data.primitive } == expected
+    }
 
     static var allTests = [
         ("testInt_0x80_toASN1", testInt_0x80_toASN1),
@@ -82,6 +110,10 @@ final class IntExtASN1EncodingTest: XCTestCase {
         ("testInt_0xff78_toASN1", testInt_0xff78_toASN1),
         ("testInt_0x800001_toASN1", testInt_0x800001_toASN1),
         ("testMinInt_toASN1", testMinInt_toASN1),
-        ("testMaxInt_toASN1", testMaxInt_toASN1)
+        ("testMaxInt_toASN1", testMaxInt_toASN1),
+        ("testUInt_0x0080_toASN1", testInt_0x0080_toASN1),
+        ("testIInt_0x7FFFFF_toASN1", testInt_0x7FFFFF_toASN1),
+        ("testMinUInt_toASN1", testMinUInt_toASN1),
+        ("testMaxUInt_toASN1", testMaxUInt_toASN1)
     ]
 }

--- a/Tests/ASN1KitTests/encodable/IntExtASN1EncodingTest.swift
+++ b/Tests/ASN1KitTests/encodable/IntExtASN1EncodingTest.swift
@@ -20,6 +20,12 @@ import XCTest
 
 // https://www.strozhevsky.com/free_docs/asn1_by_simple_words.pdf
 final class IntExtASN1EncodingTest: XCTestCase {
+    func testEnumerated_toASN1() {
+        //0x0080 = 8388607
+        let expected = Data([0x0A, 0x03, 0x7F, 0xFF, 0xFF])
+        expect(try 8388607.asn1encode(tag: .universal(.enumerated)).serialize()) == expected
+    }
+
     func testInt_0x80_toASN1() {
         //0x80 = -128
         let expected = Data([0x80])
@@ -103,6 +109,7 @@ final class IntExtASN1EncodingTest: XCTestCase {
     }
 
     static var allTests = [
+        ("testEnumerated_toASN1", testEnumerated_toASN1),
         ("testInt_0x80_toASN1", testInt_0x80_toASN1),
         ("testInt_0x0080_toASN1", testInt_0x0080_toASN1),
         ("testInt_0x7FFFFF_toASN1", testInt_0x7FFFFF_toASN1),
@@ -114,6 +121,6 @@ final class IntExtASN1EncodingTest: XCTestCase {
         ("testUInt_0x0080_toASN1", testInt_0x0080_toASN1),
         ("testIInt_0x7FFFFF_toASN1", testInt_0x7FFFFF_toASN1),
         ("testMinUInt_toASN1", testMinUInt_toASN1),
-        ("testMaxUInt_toASN1", testMaxUInt_toASN1)
+        ("testMaxUInt_toASN1", testMaxUInt_toASN1),
     ]
 }


### PR DESCRIPTION
Support for encoding `UInt` as well as allowing arbitrary tags to be specified when encoding integers, so that `ENUMERATED` can be specified.