### PR TITLE
Don't demote zero-length octet strings to null values

### DIFF
--- a/Sources/ASN1Kit/ASN1Decoder.swift
+++ b/Sources/ASN1Kit/ASN1Decoder.swift
@@ -222,7 +222,8 @@ public class ASN1Decoder {
 
     class func createPrimitive(tag: ASN1Tag, length: Int, scanner: DataScanner) throws -> ASN1Object {
         guard length > 0 else {
-            return ASN1Tag.null.toPrimitive(with: Data.empty)
+            let tag: ASN1Tag = tag == .octetString ? .octetString : .null
+            return tag.toPrimitive(with: Data.empty)
         }
         guard let data = scanner.scan(distance: length) else {
             DLog("Decoding ASN.1 Scanner has no bytes left")

--- a/Tests/ASN1KitTests/ASN1DecoderTest.swift
+++ b/Tests/ASN1KitTests/ASN1DecoderTest.swift
@@ -348,6 +348,12 @@ final class ASN1DecoderTest: XCTestCase { //swiftlint:disable:this type_body_len
         expect(try ASN1Decoder.decode(asn1: data).asEquatable()) == expected.asEquatable()
     }
 
+    func testASN1DecodePrimitiveZeroLengthOctetString() {
+        let expected = ASN1Primitive(data: .primitive(Data.empty), tag: .universal(.octetString))
+        let data = Data([0x4, 0x0])
+        expect(try ASN1Decoder.decode(asn1: data).asEquatable()) == expected.asEquatable()
+    }
+
     func testASN1DecodeConstructedOctetString() {
         let expected = ASN1Primitive(
                 data: .constructed([
@@ -425,6 +431,7 @@ final class ASN1DecoderTest: XCTestCase { //swiftlint:disable:this type_body_len
         ("testASN1DecodePrimitiveInteger", testASN1DecodePrimitiveInteger),
         ("testASN1DecodePrimitiveNull", testASN1DecodePrimitiveNull),
         ("testASN1DecodePrimitiveOctetString", testASN1DecodePrimitiveOctetString),
+        ("testASN1DecodePrimitiveZeroLengthOctetString", testASN1DecodePrimitiveZeroLengthOctetString),
         ("testASN1DecodeConstructedOctetString", testASN1DecodeConstructedOctetString),
         ("testASN1DecodeConstructedSet", testASN1DecodeConstructedSet),
         ("testASN1DecodeConstructedSequence", testASN1DecodeConstructedSequence)


### PR DESCRIPTION
Zero-length octet strings should remain as zero-length octet strings, rather than being demoted to a null value.